### PR TITLE
Catch the IndexError in the Camera class

### DIFF
--- a/robohatlib/hal/Camera.py
+++ b/robohatlib/hal/Camera.py
@@ -41,7 +41,7 @@ class Camera:
             picam2.close()
 
             self.__cam_is_not_available = True                  # cam is available
-        except Exception as e:
+        except (RuntimeError, IndexError) as e:
             print("Error when trying to initialize camera:", e)
             print("No attached camera found")
 

--- a/robohatlib/hal/Camera.py
+++ b/robohatlib/hal/Camera.py
@@ -41,7 +41,8 @@ class Camera:
             picam2.close()
 
             self.__cam_is_not_available = True                  # cam is available
-        except RuntimeError:
+        except Exception as e:
+            print("Error when trying to initialize camera:", e)
             print("No attached camera found")
 
     # --------------------------------------------------------------------------------------


### PR DESCRIPTION
In revolve v2 physical_interface, the robot daemon needs to call the Robohat base class regardless of whether the physical camera is attached or not. When a camera is not attached, the daemon will encounter the following error:
```
Oct 16 23:59:12 robohat python[16746]:   File "/home/robo/revolve2/modular_robot_physical/revolve2/modular_robot_physical/physical_interfaces/v2/_v2_physical_interface.py", line 81, in>
Oct 16 23:59:12 robohat python[16746]:     self._robohat = Robohat(
Oct 16 23:59:12 robohat python[16746]:                     ^^^^^^^^
Oct 16 23:59:12 robohat python[16746]:   File "/home/robo/robothat_revolve/robohatlib/Robohat.py", line 127, in __init__
Oct 16 23:59:12 robohat python[16746]:     self.__camera = Camera()
Oct 16 23:59:12 robohat python[16746]:                     ^^^^^^^^
Oct 16 23:59:12 robohat python[16746]:   File "/home/robo/robothat_revolve/robohatlib/hal/Camera.py", line 38, in __init__
Oct 16 23:59:12 robohat python[16746]:     picam2 = Picamera2()
Oct 16 23:59:12 robohat python[16746]:              ^^^^^^^^^^^
Oct 16 23:59:12 robohat python[16746]:   File "/home/robo/.pyenv/versions/global_env/lib/python3.11/site-packages/picamera2/picamera2.py", line 257, in __init__
Oct 16 23:59:12 robohat python[16746]:     camera_num = self.global_camera_info()[camera_num]['Num']
Oct 16 23:59:12 robohat python[16746]:                  ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
Oct 16 23:59:12 robohat python[16746]: IndexError: list index out of range

```

It's coming from the constructor of the `Camera` class, where it can't catch the `IndexError`.